### PR TITLE
nls: Add meson option to enable/disable NLS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,9 @@ glib_mkenums = find_program('glib-mkenums')
 
 subdir('headers')
 subdir('schemas')
-subdir('po')
+if get_option('nls')
+  subdir('po')
+endif
 
 # Keep this in sync with post-install.py expected arguments
 meson.add_install_script('build-aux/meson/post-install.py',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,7 @@ option('introspection',
        description: 'Whether to build introspection files',
        type: 'boolean',
        value: true)
+option('nls',
+       description: 'Whether to build native language support',
+       type: 'boolean',
+       value: true)


### PR DESCRIPTION
New meson option to enable/disable Native Language Support.
See https://packages.gentoo.org/useflags/nls for motivation.